### PR TITLE
Fix TLS chain failure and make setup resilient to API errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This sensor uses official API provided by MPK Kraków.
 | --- | --- | --- | --- | --- |
 | `name` | `string` | `False` | `MPK KR` | Name of sensor |
 | `stops` | `list` | `True` | - | List of stop configurations |
+| `ca_bundle` | `string` | `False` | - | Path to a CA bundle used to verify TTSS certificates. See [*TLS certificate issue*](#tls-certificate-issue) |
+| `verify_ssl` | `boolean` | `False` | `True` | Set to `False` to disable certificate verification. Ignored when `ca_bundle` is set |
 
 ### Stop configuration
 
@@ -76,6 +78,47 @@ wget https://github.com/PiotrMachowski/Home-Assistant-custom-components-MPK-KR/r
 unzip mpk_kr.zip
 rm mpk_kr.zip
 ```
+
+## TLS certificate issue
+
+TTSS servers send an **incomplete certificate chain**: instead of the intermediate certificate
+(`Certum OV TLS G2 R39 CA`) they send the root certificate (`Certum Trusted Root CA`).
+
+Web browsers hide this problem by downloading the missing intermediate certificate through the AIA
+extension. Python does not do that, so the integration fails with:
+
+```
+SSLError: CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate
+```
+
+This has been reported to MPK Kraków. Until it is fixed on their side, the missing certificate has to
+be provided locally.
+
+1. Download the intermediate certificate and save it together with the root certificate as
+   `config/mpk_ca.pem`:
+
+   ```bash
+   curl -s http://certumovtlsg2r39ca.repository.certum.pl/certumovtlsg2r39ca.cer \
+     | openssl x509 -inform DER -outform PEM > config/mpk_ca.pem
+   curl -s http://subca.repository.certum.pl/ctrca.cer \
+     | openssl x509 -inform DER -outform PEM >> config/mpk_ca.pem
+   ```
+
+   Both URLs come from the `Authority Information Access` extension of the certificates themselves.
+
+2. Point the integration to it:
+
+   ```yaml
+   sensor:
+     - platform: mpk_kr
+       ca_bundle: /config/mpk_ca.pem
+       stops:
+         - id: 623
+           platform: bus
+   ```
+
+As a last resort `verify_ssl: false` disables certificate verification entirely. This is **not
+recommended** – it removes protection against man-in-the-middle attacks.
 
 ## Hints
 

--- a/custom_components/mpk_kr/sensor.py
+++ b/custom_components/mpk_kr/sensor.py
@@ -1,12 +1,16 @@
+import logging
+
 import requests
 
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
-from homeassistant.const import CONF_ID, CONF_NAME
+from homeassistant.const import CONF_ID, CONF_NAME, CONF_VERIFY_SSL
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity import async_generate_entity_id
+
+_LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'MPK KR'
 
@@ -15,9 +19,14 @@ CONF_PLATFORM = 'platform'
 CONF_LINES = 'lines'
 CONF_MODE = 'mode'
 CONF_DIRECTIONS = 'directions'
+CONF_CA_BUNDLE = 'ca_bundle'
+
+REQUEST_TIMEOUT = 10
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
+    vol.Optional(CONF_CA_BUNDLE): cv.isfile,
     vol.Required(CONF_STOPS): vol.All(cv.ensure_list, [
         vol.Schema({
             vol.Required(CONF_ID): cv.positive_int,
@@ -33,6 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     name = config.get(CONF_NAME)
     stops = config.get(CONF_STOPS)
+    verify = config.get(CONF_CA_BUNDLE) or config.get(CONF_VERIFY_SSL)
     dev = []
     for stop in stops:
         stop_id = str(stop.get(CONF_ID))
@@ -41,27 +51,35 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         directions = stop.get(CONF_DIRECTIONS)
         mode = stop.get(CONF_MODE)
         if mode not in ["departure", "arrival"]:
-            raise Exception("Invalid mode: {}".format(mode))
+            _LOGGER.error("Invalid mode '%s' for stop %s, skipping this stop", mode, stop_id)
+            continue
         if platform not in ["tram", "bus"]:
-            raise Exception("Invalid platform: {}".format(platform))
-        real_stop_name = MpkKrSensor.get_stop_name(stop_id, platform)
+            _LOGGER.error("Invalid platform '%s' for stop %s, skipping this stop", platform, stop_id)
+            continue
+        real_stop_name = MpkKrSensor.get_stop_name(stop_id, platform, verify)
         if real_stop_name is None:
-            raise Exception("Invalid stop id: {}".format(stop_id))
+            _LOGGER.warning("No data returned for stop %s (%s), skipping this stop", stop_id, platform)
+            continue
         stop_name = stop.get(CONF_NAME) or stop_id
         uid = '{}_{}_{}_{}'.format(name, stop_name, platform, mode)
         entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, uid, hass=hass)
-        dev.append(MpkKrSensor(entity_id, name, stop_id, platform, mode, stop_name, real_stop_name, lines, directions))
+        dev.append(MpkKrSensor(entity_id, name, stop_id, platform, mode, stop_name, real_stop_name, lines, directions,
+                               verify))
+    if not dev:
+        _LOGGER.error("No sensors were created, check stop ids and TTSS availability")
+        return
     add_entities(dev, True)
 
 
 class MpkKrSensor(Entity):
     def __init__(self, entity_id, name, stop_id, platform, mode, stop_name, real_stop_name, watched_lines,
-                 watched_directions):
+                 watched_directions, verify=True):
         self.entity_id = entity_id
         self._name = name
         self._stop_id = stop_id
         self._platform = platform
         self._mode = mode
+        self._verify = verify
         self._watched_lines = watched_lines
         self._watched_directions = watched_directions
         self._stop_name = stop_name
@@ -108,10 +126,10 @@ class MpkKrSensor(Entity):
         return attr
 
     def update(self):
-        data = MpkKrSensor.get_data(self._stop_id, self._platform, self._mode)
+        data = MpkKrSensor.get_data(self._stop_id, self._platform, self._mode, self._verify)
         if data is None:
             return
-        departures = data["actual"]
+        departures = data.get("actual") or []
         parsed_departures = []
         for departure in departures:
             line = departure["patternText"]
@@ -182,19 +200,33 @@ class MpkKrSensor(Entity):
         return departures_by_line
 
     @staticmethod
-    def get_stop_name(stop_id, platform):
-        data = MpkKrSensor.get_data(stop_id, platform)
+    def get_stop_name(stop_id, platform, verify=True):
+        data = MpkKrSensor.get_data(stop_id, platform, verify=verify)
         if data is None:
             return None
-        return data["stopName"]
+        return data.get("stopName")
 
     @staticmethod
-    def get_data(stop_id, platform, mode="departure"):
+    def get_data(stop_id, platform, mode="departure", verify=True):
         base_url_tram = 'https://www.ttss.krakow.pl/internetservice/services/passageInfo/stopPassages/stop?stop={}&mode={}&language=pl'
         base_url_bus = 'https://ttss.mpk.krakow.pl/internetservice/services/passageInfo/stopPassages/stop?stop={}&mode={}'
         base_url = base_url_tram if platform == "tram" else base_url_bus
         address = base_url.format(stop_id, mode)
-        response = requests.get(address)
-        if response.status_code == 200 and response.content.__len__() > 0:
+        try:
+            response = requests.get(address, timeout=REQUEST_TIMEOUT, verify=verify)
+        except requests.exceptions.SSLError as err:
+            _LOGGER.warning("SSL error for stop %s: %s. TTSS servers send an incomplete certificate chain; "
+                            "see README for the 'ca_bundle' option", stop_id, err)
+            return None
+        except requests.exceptions.RequestException as err:
+            _LOGGER.warning("Connection error for stop %s: %s", stop_id, err)
+            return None
+        if response.status_code != 200 or len(response.content) == 0:
+            _LOGGER.warning("Unexpected response for stop %s: HTTP %s, %s bytes",
+                            stop_id, response.status_code, len(response.content))
+            return None
+        try:
             return response.json()
-        return None
+        except ValueError as err:
+            _LOGGER.warning("Invalid JSON for stop %s: %s", stop_id, err)
+            return None


### PR DESCRIPTION
## Problem

The integration currently fails to create any entities. There are three separate causes, all reproducible on a stock Home Assistant OS install.

### 1. Incomplete certificate chain (root cause of #9)

TTSS servers send the **root** certificate instead of the **intermediate** one:

```
$ openssl s_client -connect ttss.mpk.krakow.pl:443 -servername ttss.mpk.krakow.pl
 0 s:CN=*.mpk.krakow.pl            i:CN=Certum OV TLS G2 R39 CA
 1 s:CN=Certum Trusted Root CA     i:CN=Certum Trusted Root CA   <- should be the intermediate
```

Browsers hide this by fetching the missing intermediate through the certificate's AIA extension. Python/OpenSSL deliberately does not, so every request fails:

```
SSLError: CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate
```

This is a server-side misconfiguration at MPK, **not** something that can be fixed in this repository. **It has been reported to MPK Kraków** (kontakt@mpk.krakow.pl) with the details above and a request to publish the correct chain. Until they act, users need a way to supply the missing certificate themselves, so this PR adds a `ca_bundle` option and documents how to build the bundle from the URLs published in the certificates' own AIA extensions.

Verified working:

```
$ curl --cacert mpk_ca.pem -o /dev/null -w "HTTP=%{http_code} ssl_verify=%{ssl_verify_result}\n" \
    "https://ttss.mpk.krakow.pl/internetservice/services/passageInfo/stopPassages/stop?stop=747&mode=departure"
HTTP=200 ssl_verify=0
```

### 2. No request timeout blocks Home Assistant startup

`requests.get()` was called without a timeout. When TTSS is slow or unreachable, setup hangs indefinitely:

```
19:00:22 Setting up mpk_kr.sensor
19:00:32 WARNING  Setup of sensor platform mpk_kr is taking over 10 seconds.
19:01:29 ERROR    Setup of platform mpk_kr is taking longer than 60 seconds.
                  Startup will proceed without waiting any longer.
```

No traceback, no entities, and 60 s added to every restart. This makes the failure very hard to diagnose — the original report in #9 assumed a JSON parsing problem.

### 3. One bad stop kills every other stop

`setup_platform` raised on the first stop that returned no data, so a single unreachable or invalid id removed the sensors for all remaining stops. This is what makes #10 painful: an invalid stop id from the map takes down an otherwise working configuration.

## Changes

- Added `ca_bundle` (path to a CA bundle) and `verify_ssl` (boolean, default `True`) platform options, passed through to `requests`.
- Added a 10 s request timeout.
- Wrapped requests and JSON decoding in `try`/`except`; failures are logged with the stop id, HTTP status and response length instead of propagating. `SSLError` gets a dedicated message pointing at the `ca_bundle` option.
- Invalid `mode`/`platform`, and stops that return no data, are now logged and skipped instead of raising. If no sensors could be created at all, a single clear error is logged.
- `data["actual"]` / `data["stopName"]` changed to `.get()` to avoid `KeyError` on truncated responses.
- README: documented both new options and added a "TLS certificate issue" section with the exact commands to build the bundle.

## Notes

- No behaviour change for working configurations — the defaults keep certificate verification enabled.
- The `ca_bundle` workaround becomes unnecessary once MPK fixes its chain; leaving it configured does no harm.
- Tested on Home Assistant 2026.7.2 with four bus stops; entities are created and populated correctly.
